### PR TITLE
Fix NanoBlade being unusable

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Constants.java
@@ -5,9 +5,6 @@ import org.bukkit.NamespacedKey;
 
 public final class Constants {
 
-    public static final NamespacedKey GLOW_ENCHANT = new NamespacedKey(LiteXpansion.getInstance(),
-        "glow_enchant");
-
     public static final NamespacedKey NANO_BLADE_ENABLED = new NamespacedKey(LiteXpansion.getInstance(),
         "nano_blade_enabled");
 

--- a/src/main/java/dev/j3fftw/litexpansion/weapons/NanoBlade.java
+++ b/src/main/java/dev/j3fftw/litexpansion/weapons/NanoBlade.java
@@ -16,6 +16,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -27,6 +28,12 @@ public class NanoBlade extends SimpleSlimefunItem<ItemUseHandler> implements Rec
 
     public static final float CAPACITY = 4_000;
     public static final float PER_TICK_REMOVAL = 64;
+
+    /**
+     * A real vanilla enchantment used purely to render the "powered on" glow.
+     * The tooltip entry is hidden via {@link ItemFlag#HIDE_ENCHANTS}.
+     */
+    private static final Enchantment GLOW_ENCHANTMENT = Enchantment.LUCK;
 
     public NanoBlade() {
         super(Items.LITEXPANSION, Items.NANO_BLADE, MetalForge.RECIPE_TYPE, new ItemStack[] {
@@ -47,21 +54,24 @@ public class NanoBlade extends SimpleSlimefunItem<ItemUseHandler> implements Rec
     public ItemUseHandler getItemHandler() {
         return event -> {
             final ItemMeta nanoBladeMeta = event.getItem().getItemMeta();
-            final Enchantment enchantment = Enchantment.getByKey(Constants.GLOW_ENCHANT);
-            boolean enabled = !nanoBladeMeta.removeEnchant(enchantment);
+            boolean enabled = !isEnabled(nanoBladeMeta);
 
             int damage;
 
             if (enabled && getItemCharge(event.getItem()) > getRemovedChargePerTick()) {
-                nanoBladeMeta.addEnchant(enchantment, 1, false);
+                nanoBladeMeta.addEnchant(GLOW_ENCHANTMENT, 1, true);
                 nanoBladeMeta.setDisplayName(ChatColor.DARK_GREEN + "纳米剑" + ChatColor.GREEN + " (开)");
 
                 damage = 13; // Base is 7 so 7 + 13 = 20
             } else {
+                enabled = false;
+                nanoBladeMeta.removeEnchant(GLOW_ENCHANTMENT);
                 nanoBladeMeta.setDisplayName(ChatColor.DARK_GREEN + "纳米剑" + ChatColor.RED + " (关)");
 
                 damage = -3; // Base is 7 so 7 - 3 = 4
             }
+
+            nanoBladeMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 
             PersistentDataAPI.setBoolean(nanoBladeMeta, Constants.NANO_BLADE_ENABLED, enabled);
 
@@ -90,6 +100,6 @@ public class NanoBlade extends SimpleSlimefunItem<ItemUseHandler> implements Rec
     public boolean isEnabled(@Nonnull ItemMeta meta) {
         final Optional<Boolean> opt = Utils.getOptionalBoolean(meta, Constants.NANO_BLADE_ENABLED);
 
-        return (opt.isPresent() && opt.get()) || meta.hasEnchant(Enchantment.getByKey(Constants.GLOW_ENCHANT));
+        return opt.isPresent() && opt.get();
     }
 }


### PR DESCRIPTION
Enchantment.getByKey(Constants.GLOW_ENCHANT) always returned null because the custom litexpansion:glow_enchant enchantment was never registered, so right-clicking the blade threw an exception and the item could not be toggled.

- Track enabled state purely via PersistentData (NANO_BLADE_ENABLED)
- Use a real vanilla enchantment (Enchantment.LUCK) with HIDE_ENCHANTS only for the powered-on glow
- Keep the state consistent when there is not enough charge to enable